### PR TITLE
Update config for Lita 4.0

### DIFF
--- a/lib/lita/handlers/logger.rb
+++ b/lib/lita/handlers/logger.rb
@@ -5,10 +5,8 @@ module Lita
     class Logger < Handler
 
 
-      def self.default_config(config)
-        config.log_file = nil
-        config.enable_http_log = false
-      end
+      config :log_file
+      config :enable_http_log, default: false
 
       route(/.*/, :logger)
 


### PR DESCRIPTION
Removes deprecation warnings by updating config according to the [developer upgrade guide](http://docs.lita.io/releases/4/#upgrading-for-developers).
